### PR TITLE
Adds confidence interval for line plots

### DIFF
--- a/example/confidence-interval.md
+++ b/example/confidence-interval.md
@@ -1,0 +1,37 @@
+# Confidence Interval
+
+A confidence interval is a range of values so defined that there is a specified probability that the value of a parameter lies within it.
+
+The [.confidence( )](http://d3plus.org/docs/#Plot.confidence) method allows us to specify an array of accessors for the lower and upper bounds of a confidence interval (in the format `[lower, upper]`).
+
+Given this data array:
+
+```js
+var data = [
+  {fruit: "apple", year: 1, amount:  50, moe: 2},
+  {fruit: "apple", year: 2, amount: 56, moe: 1},
+  {fruit: "apple", year: 3, amount: 58, moe: 1},
+  {fruit: "banana", year: 1, amount: 88, moe: 3},
+  {fruit: "banana", year: 2, amount:  90, moe: 4},
+  {fruit: "banana", year: 3, amount: 76, moe: 3}
+];
+```
+
+We can create a Line Plot with confidence intervals:
+
+```js
+new d3plus.LinePlot()
+  .data(data)
+  .groupBy("fruit")
+  .x("year")
+  .y("amount")
+  .confidence([
+    function(d) {
+      return d.amount - d.moe
+    },
+    function(d) {
+      return d.amount + d.moe
+    },
+  ])
+  .render();
+```

--- a/example/confidence-interval.md
+++ b/example/confidence-interval.md
@@ -4,6 +4,8 @@ A confidence interval is a range of values so defined that there is a specified 
 
 The [.confidence( )](http://d3plus.org/docs/#Plot.confidence) method allows us to specify an array of accessors for the lower and upper bounds of a confidence interval (in the format `[lower, upper]`).
 
+The [.confidenceConfig( )](http://d3plus.org/docs/#Plot.confidenceConfig) method works similarly to the [.shapeConfig( )](http://d3plus.org/docs/#Viz.shapeConfig) method, but the configuration is only applied to shapes rendered as part of the confidence interval.
+
 Given this data array:
 
 ```js
@@ -33,5 +35,8 @@ new d3plus.LinePlot()
       return d.amount + d.moe
     },
   ])
+  .confidenceConfig({
+    fillOpacity: 0.3
+  })
   .render();
 ```

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -41,6 +41,9 @@ export default class Plot extends Viz {
       Line: LineBuffer,
       Rect: RectBuffer
     };
+    this._confidenceConfig = {
+      fillOpacity: constant(0.5)
+    };
     this._groupPadding = 5;
     this._shape = constant("Circle");
     this._shapeConfig = assign(this._shapeConfig, {
@@ -652,8 +655,9 @@ export default class Plot extends Viz {
         areaConfig[`${key}0`] = d => scaleFunction(this._confidence[0] ? d.lci : d[key]);
         areaConfig[`${key}1`] = d => scaleFunction(this._confidence[1] ? d.hci : d[key]);
 
-        const area = new shapes.Area().config(areaConfig).fillOpacity(0.5).data(d.values);
-        area.config(configPrep.bind(this)(this._shapeConfig, "shape", "Area")).render();
+        const area = new shapes.Area().config(areaConfig).data(d.values);
+        const confidenceConfig = Object.assign(this._shapeConfig, this._confidenceConfig);
+        area.config(configPrep.bind(this)(confidenceConfig, "shape", "Area")).render();
         this._shapes.push(area);
       }
 
@@ -728,6 +732,16 @@ export default class Plot extends Viz {
       return this;
     }
     else return this._confidence;
+  }
+
+  /**
+       @memberof Plot
+       @desc If *value* is specified, sets the config method for each shape rendered as a confidence interval and returns the current class instance.
+       @param {Object} [*value*]
+       @chainable
+   */
+  confidenceConfig(_) {
+    return arguments.length ? (this._confidenceConfig = assign(this._confidenceConfig, _), this) : this._confidenceConfig;
   }
 
   /**

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -649,8 +649,8 @@ export default class Plot extends Viz {
         const areaConfig = Object.assign({}, shapeConfig);
         const key = this._discrete === "x" ? "y" : "x";
         const scaleFunction = this._discrete === "x" ? y : x;
-        areaConfig[`${key}0`] = d => scaleFunction(d.lci);
-        areaConfig[`${key}1`] = d => scaleFunction(d.hci);
+        areaConfig[`${key}0`] = d => scaleFunction(this._confidence[0] ? d.lci : d[key]);
+        areaConfig[`${key}1`] = d => scaleFunction(this._confidence[1] ? d.hci : d[key]);
 
         const area = new shapes.Area().config(areaConfig).fillOpacity(0.5).data(d.values);
         area.config(configPrep.bind(this)(this._shapeConfig, "shape", "Area")).render();

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -682,6 +682,25 @@ export default class Plot extends Viz {
   }
 
   /**
+       @memberof Plot
+       @desc Sets the confidence to the specified array of lower and upper bounds.
+       @param {Array} *value*
+       @chainable
+   */
+  confidence(_) {
+    if (arguments.length) {
+      this._confidence = [];
+      const lower = _[0];
+      this._confidence[0] = typeof lower === "function" || !lower ? lower : accessor(lower);
+      const upper = _[1];
+      this._confidence[1] = typeof upper === "function" || !upper ? upper : accessor(upper);
+
+      return this;
+    }
+    else return this._confidence;
+  }
+
+  /**
       @memberof Plot
       @desc Sets the discrete axis to the specified string. If *value* is not specified, returns the current discrete axis.
       @param {String} *value*

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -125,7 +125,9 @@ export default class Plot extends Viz {
       data: d,
       group: stackGroup(d, i),
       i,
+      hci: this._confidence && this._confidence[1] && this._confidence[1](d, i),
       id: this._ids(d, i).slice(0, this._drawDepth + 1).join("_"),
+      lci: this._confidence && this._confidence[0] && this._confidence[0](d, i),
       shape: this._shape(d, i),
       x: this._x(d, i),
       x2: this._x2(d, i),
@@ -633,6 +635,23 @@ export default class Plot extends Viz {
         s.width(barSize);
         s.height(barSize);
 
+      }
+      else if (d.key === "Line" && this._confidence) {
+
+        const key = this._discrete === "x" ? "y" : "x";
+        const discrete = this._discrete === "x" ? "x" : "y";
+        const areaConfig = Object.assign({}, shapeConfig);
+        areaConfig[key] = null;
+        areaConfig[`${key}0`] = d => y(d.lci);
+        areaConfig[`${key}1`] = d => y(d.hci);
+        areaConfig[`${discrete}0`] = null;
+        areaConfig[`${discrete}1`] = null;
+
+        console.log(areaConfig);
+
+        const area = new shapes.Area().config(areaConfig).data(d.values);
+        area.config(configPrep.bind(this)(this._shapeConfig, "shape", "Area")).render();
+        this._shapes.push(area);
       }
 
       const classEvents = events.filter(e => e.includes(`.${d.key}`)),

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -638,18 +638,13 @@ export default class Plot extends Viz {
       }
       else if (d.key === "Line" && this._confidence) {
 
-        const key = this._discrete === "x" ? "y" : "x";
-        const discrete = this._discrete === "x" ? "x" : "y";
         const areaConfig = Object.assign({}, shapeConfig);
-        areaConfig[key] = null;
-        areaConfig[`${key}0`] = d => y(d.lci);
-        areaConfig[`${key}1`] = d => y(d.hci);
-        areaConfig[`${discrete}0`] = null;
-        areaConfig[`${discrete}1`] = null;
+        const key = this._discrete === "x" ? "y" : "x";
+        const scaleFunction = this._discrete === "x" ? y : x;
+        areaConfig[`${key}0`] = d => scaleFunction(d.lci);
+        areaConfig[`${key}1`] = d => scaleFunction(d.hci);
 
-        console.log(areaConfig);
-
-        const area = new shapes.Area().config(areaConfig).data(d.values);
+        const area = new shapes.Area().config(areaConfig).fillOpacity(0.5).data(d.values);
         area.config(configPrep.bind(this)(this._shapeConfig, "shape", "Area")).render();
         this._shapes.push(area);
       }

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -247,10 +247,18 @@ export default class Plot extends Viz {
 
     }
     else {
+      const xData = this._discrete === "x" ? data.map(d => d.x) : data.map(d => d.x)
+        .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
+        .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
+
+      const yData = this._discrete === "y" ? data.map(d => d.y) : data.map(d => d.y)
+        .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
+        .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
+
       domains = {
-        x: this._xSort ? Array.from(new Set(data.filter(d => d.x).sort((a, b) =>  this._xSort(a.data, b.data)).map(d => d.x))) : extent(data, d => d.x),
+        x: this._xSort ? Array.from(new Set(data.filter(d => d.x).sort((a, b) =>  this._xSort(a.data, b.data)).map(d => d.x))) : extent(xData, d => d),
         x2: this._x2Sort ? Array.from(new Set(data.filter(d => d.x2).sort((a, b) =>  this._x2Sort(a.data, b.data)).map(d => d.x2))) : extent(data, d => d.x2),
-        y: this._ySort ? Array.from(new Set(data.filter(d => d.y).sort((a, b) =>  this._ySort(a.data, b.data)).map(d => d.y))) : extent(data, d => d.y),
+        y: this._ySort ? Array.from(new Set(data.filter(d => d.y).sort((a, b) =>  this._ySort(a.data, b.data)).map(d => d.y))) : extent(yData, d => d),
         y2: this._y2Sort ? Array.from(new Set(data.filter(d => d.y2).sort((a, b) =>  this._y2Sort(a.data, b.data)).map(d => d.y2))) : extent(data, d => d.y2)
       };
     }

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -706,8 +706,16 @@ export default class Plot extends Viz {
   /**
        @memberof Plot
        @desc Sets the confidence to the specified array of lower and upper bounds.
-       @param {Array} *value*
+       @param {String[]|Function[]} *value*
        @chainable
+       @example <caption>Can be called with accessor functions or static keys:</caption>
+       var data = {id: "alpha", value: 10, lci: 9, hci: 11};
+       ...
+       // Accessor functions
+       .confidence([function(d) { return d.lci }, function(d) { return d.hci }])
+
+       // Or static keys
+       .confidence(["lci", "hci"])
    */
   confidence(_) {
     if (arguments.length) {

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -254,15 +254,23 @@ export default class Plot extends Viz {
         .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
         .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
 
+      const x2Data = this._discrete === "x" ? data.map(d => d.x2) : data.map(d => d.x2)
+        .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
+        .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
+
       const yData = this._discrete === "y" ? data.map(d => d.y) : data.map(d => d.y)
+        .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
+        .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
+
+      const y2Data = this._discrete === "y" ? data.map(d => d.y2) : data.map(d => d.y2)
         .concat(this._confidence && this._confidence[0] ? data.map(d => d.lci)  : [])
         .concat(this._confidence && this._confidence[1] ? data.map(d => d.hci) : []);
 
       domains = {
         x: this._xSort ? Array.from(new Set(data.filter(d => d.x).sort((a, b) =>  this._xSort(a.data, b.data)).map(d => d.x))) : extent(xData, d => d),
-        x2: this._x2Sort ? Array.from(new Set(data.filter(d => d.x2).sort((a, b) =>  this._x2Sort(a.data, b.data)).map(d => d.x2))) : extent(data, d => d.x2),
+        x2: this._x2Sort ? Array.from(new Set(data.filter(d => d.x2).sort((a, b) =>  this._x2Sort(a.data, b.data)).map(d => d.x2))) : extent(x2Data, d => d),
         y: this._ySort ? Array.from(new Set(data.filter(d => d.y).sort((a, b) =>  this._ySort(a.data, b.data)).map(d => d.y))) : extent(yData, d => d),
-        y2: this._y2Sort ? Array.from(new Set(data.filter(d => d.y2).sort((a, b) =>  this._y2Sort(a.data, b.data)).map(d => d.y2))) : extent(data, d => d.y2)
+        y2: this._y2Sort ? Array.from(new Set(data.filter(d => d.y2).sort((a, b) =>  this._y2Sort(a.data, b.data)).map(d => d.y2))) : extent(y2Data, d => d)
       };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Adds a `.confidence( )` method to the `Plot` class which allows the user to specify upper and lower bounds of a confidence interval.

(closes #70 )

### Description
<!--- Describe your changes in detail -->
The `.confidence( )` method accepts an array of accessors for the upper and lower bounds of a confidence interval.

This method only works with the `LinePlot` class. When rendering LinePlots with a confidence interval, the upper and lower bounds will be rendered as an `Area` shape behind the line.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [x] I have written examples for all new methods/functionality.

