### PR TITLE
adds checks for x2Domain and y2Domain before accessing values

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -288,8 +288,8 @@ export default class Plot extends Viz {
     let x2Domain = this._x2Domain ? this._x2Domain.slice() : domains.x2,
         x2Scale = this._x2Sort ? "Ordinal" : "Linear";
 
-    if (x2Domain[0] === void 0) x2Domain[0] = domains.x2[0];
-    if (x2Domain[1] === void 0) x2Domain[1] = domains.x2[1];
+    if (x2Domain && x2Domain[0] === void 0) x2Domain[0] = domains.x2[0];
+    if (x2Domain && x2Domain[1] === void 0) x2Domain[1] = domains.x2[1];
 
     if (x2Time) {
       x2Domain = x2Domain.map(date);
@@ -313,8 +313,8 @@ export default class Plot extends Viz {
     let y2Domain = this._y2Domain ? this._y2Domain.slice() : domains.y2,
         y2Scale = this._y2Sort ? "Ordinal" : "Linear";
 
-    if (y2Domain[0] === void 0) y2Domain[0] = domains.y2[0];
-    if (y2Domain[1] === void 0) y2Domain[1] = domains.y2[1];
+    if (y2Domain && y2Domain[0] === void 0) y2Domain[0] = domains.y2[0];
+    if (y2Domain && y2Domain[1] === void 0) y2Domain[1] = domains.y2[1];
 
     if (yTime) {
       yDomain = yDomain.map(date);
@@ -333,13 +333,14 @@ export default class Plot extends Viz {
       y2Scale = "Time";
     }
 
-    domains = {x: xDomain, x2: x2Domain, y: yDomain, y2: y2Domain};
+
+    domains = {x: xDomain, x2: x2Domain || xDomain, y: yDomain, y2: y2Domain || yDomain};
 
     opps.forEach(opp => {
       if (opp && this._baseline !== void 0) {
         const b = this._baseline;
-        if (domains[opp][0] > b) domains[opp][0] = b;
-        else if (domains[opp][1] < b) domains[opp][1] = b;
+        if (domains[opp] && domains[opp][0] > b) domains[opp][0] = b;
+        else if (domains[opp] && domains[opp][1] < b) domains[opp][1] = b;
       }
     });
 


### PR DESCRIPTION
Adds checks for x2Domain and y2Domain before accessing values and defaults to x and y domains if secondary domains do not exist.

<!--- Provide a general summary of your changes in the title above -->


### Description
<!--- Describe your changes in detail -->
The bug was introduced with the addition of the `.confidence( )` method due to the changes to [Plot.js on line 257](https://github.com/d3plus/d3plus-plot/blob/master/src/Plot.js#L257) which cause `domains.x2` and `domains.y2` to be `undefined` when no secondary axes exist. 

To fix this bug I added checks for the x2Domain and y2Domain before accessing their values ([example](https://github.com/d3plus/d3plus-plot/blob/master/src/Plot.js#L291)) and modify [the domains object](https://github.com/d3plus/d3plus-plot/blob/master/src/Plot.js#L336) to default `x2` and `y2` to the x and y domains, if no secondary axes exist.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

