### PR TITLE
fixes default sorting in BumpChart

### DIFF
--- a/src/BumpChart.js
+++ b/src/BumpChart.js
@@ -65,8 +65,8 @@ export default class BumpChart extends Plot {
         return this._drawLabel(d, d.i);
       }
     });
-    this.ySort((a, b) => b.y - a.y);
-    this.y2Sort((a, b) => b.y - a.y);
+    this.ySort((a, b) => this._y(b) - this._y(a));
+    this.y2Sort((a, b) => this._y(b) - this._y(a));
   }
 
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
The bug was caused by calling `d.y` in the `ySort` and `y2Sort` functions in the constructor for `BumpChart`. This fixes the bug by using the y accessor `this._y` instead.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

