### PR TITLE
fixes buffers

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -350,7 +350,8 @@ export default class Plot extends Viz {
         y2 = scales[`scale${y2Scale}`]().domain(domains.y2.reverse()).range(range(0, height + 1, height / (domains.y2.length - 1)));
 
     const shapeData = nest().key(d => d.shape).entries(data);
-    if (this._xConfig.scale !== "log" && this._yConfig.scale !== "log" && ((this._discrete === "x" && yScale !== "Ordinal")) || this._discrete === "y" && xScale !== "Ordinal") {
+    const oppScale = this._discrete === "x" ? yScale : xScale;
+    if (this._xConfig.scale !== "log" && this._yConfig.scale !== "log" && oppScale !== "Ordinal") {
       shapeData.forEach(d => {
         if (this._buffer[d.key]) {
           const res = this._buffer[d.key].bind(this)({data: d.values, x, y, config: this._shapeConfig[d.key]});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #76 )
### Description
<!--- Describe your changes in detail -->
This bug was introduced in #69. I was trying to add logic on [line 353 on Plot.js](https://github.com/d3plus/d3plus-plot/blob/master/src/Plot.js#L353l) to not run the buffers when the opposite axis scale is ordinal, but implemented this logic incorrectly. This PR corrects that logic and ensures that buffers are run when they are supposed to.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

