### PR TITLE
fixes BumpChart tickFormat bug

### DIFF
--- a/src/BumpChart.js
+++ b/src/BumpChart.js
@@ -53,7 +53,7 @@ export default class BumpChart extends Plot {
         const xDomain = this._xDomain;
         const startData = data.filter(d => d.x === xDomain[0]);
         const d = startData.find(d => d.y === val);
-        return this._drawLabel(d, d.i);
+        return d ? this._drawLabel(d, d.i) : "";
       }
     });
     this.y2Config({
@@ -62,7 +62,7 @@ export default class BumpChart extends Plot {
         const xDomain = this._xDomain;
         const endData = data.filter(d => d.x === xDomain[xDomain.length - 1]);
         const d = endData.find(d => d.y === val);
-        return this._drawLabel(d, d.i);
+        return d ? this._drawLabel(d, d.i) : "";
       }
     });
     this.ySort((a, b) => this._y(b) - this._y(a));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #78 )

### Description
<!--- Describe your changes in detail -->
This bug occurs when the start and end of the data don't have the same number of values so there are a different number of rankings. [When the `tickFormat` function was looking for a value for a ranking that didn't exist](https://github.com/d3plus/d3plus-plot/blob/master/src/BumpChart.js#L29), it would error out. This change renders an empty string as the tick when this is the case because there is no value to label.

Here's an example of this case:
<img width="700" alt="screen shot 2018-03-28 at 5 23 48 pm" src="https://user-images.githubusercontent.com/9114397/38057274-d69917e6-32ac-11e8-85cd-935250a08786.png">

Orange has no value for `x: 3`, so it there is no 4th ranking.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

