### PR TITLE
applies topOffset so it is accounted for in grid line heights

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -459,17 +459,20 @@ export default class Plot extends Viz {
       .range([xOffsetLeft, undefined])
       .render();
 
-    const transform = `translate(${this._margin.left}, ${this._margin.top + x2Height})`;
-    const x2Transform = `translate(${this._margin.left}, ${this._margin.top})`;
+    const isYAxisOrdinal = yScale === "Ordinal";
+    const topOffset = isYAxisOrdinal ? this._yTest.shapeConfig().labelConfig.fontSize() : this._yTest.shapeConfig().labelConfig.fontSize() / 2;
+
+    const transform = `translate(${this._margin.left}, ${this._margin.top + x2Height + topOffset})`;
+    const x2Transform = `translate(${this._margin.left}, ${this._margin.top + topOffset})`;
 
     const xGroup = elem("g.d3plus-plot-x-axis", {parent, transition, enter: {transform}, update: {transform}});
     const x2Group = elem("g.d3plus-plot-x2-axis", {parent, transition, enter: {transform: x2Transform}, update: {transform: x2Transform}});
 
     const xTrans = xOffsetLeft > yWidth ? xOffsetLeft - yWidth : 0;
-    const yTransform = `translate(${this._margin.left + xTrans}, ${this._margin.top})`;
+    const yTransform = `translate(${this._margin.left + xTrans}, ${this._margin.top + topOffset})`;
     const yGroup = elem("g.d3plus-plot-y-axis", {parent, transition, enter: {transform: yTransform}, update: {transform: yTransform}});
 
-    const y2Transform = `translate(${this._margin.left}, ${this._margin.top})`;
+    const y2Transform = `translate(${this._margin.left}, ${this._margin.top + topOffset})`;
     const y2Group = elem("g.d3plus-plot-y2-axis", {parent, transition, enter: {transform: y2Transform}, update: {transform: y2Transform}});
 
     const xOffsetRight = max([y2Width, width - this._xTest._getRange()[1], width - this._x2Test._getRange()[1]]);
@@ -478,7 +481,7 @@ export default class Plot extends Viz {
 
     this._xAxis
       .domain(xDomain)
-      .height(height - x2Height)
+      .height(height - (x2Height + topOffset))
       .range([xOffsetLeft, width - xDifference])
       .scale(xScale.toLowerCase())
       .select(xGroup.node())
@@ -496,7 +499,7 @@ export default class Plot extends Viz {
 
     this._x2Axis
       .domain(x2Exists ? x2Domain : xDomain)
-      .height(height - xHeight)
+      .height(height - (xHeight + topOffset))
       .range([xOffsetLeft, width - x2Difference])
       .scale(x2Scale.toLowerCase())
       .select(x2Group.node())
@@ -519,8 +522,6 @@ export default class Plot extends Viz {
     };
     const xRange = this._xAxis._getRange();
 
-    const isYAxisOrdinal = yScale === "Ordinal";
-    const topOffset = isYAxisOrdinal ? this._yTest.shapeConfig().labelConfig.fontSize() : this._yTest.shapeConfig().labelConfig.fontSize() / 2;
     const yOffsetBottom = max([xHeight, height - this._yTest._getRange()[1], height - this._y2Test._getRange()[1]]);
     const yAxisOffset = height - this._yTest._getRange()[1];
     const yDifference = isYAxisOrdinal ? yOffsetBottom - yAxisOffset + this._yTest.padding() : xHeight;
@@ -528,7 +529,7 @@ export default class Plot extends Viz {
     this._yAxis
       .domain(yDomain)
       .height(height)
-      .range([this._xAxis.outerBounds().y + topOffset + x2Height, height - yDifference])
+      .range([this._xAxis.outerBounds().y + x2Height, height - (yDifference + topOffset)])
       .scale(yScale.toLowerCase())
       .select(yGroup.node())
       .ticks(yTicks)
@@ -545,7 +546,7 @@ export default class Plot extends Viz {
       .domain(y2Exists ? y2Domain : yDomain)
       .gridSize(0)
       .height(height)
-      .range([this._xAxis.outerBounds().y + x2Height + topOffset, height - y2Difference])
+      .range([this._xAxis.outerBounds().y + x2Height, height - (y2Difference + topOffset)])
       .scale(y2Exists ? y2Scale.toLowerCase() : yScale.toLowerCase())
       .select(y2Group.node())
       .width(width - max([0, xOffsetRight - y2Width]))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #80 )

### Description
<!--- Describe your changes in detail -->
The big with grid lines longer than the axis bars was being caused by the [topOffset in Plot.js](https://github.com/d3plus/d3plus-plot/blob/master/src/Plot.js#L523). I changed the way that topOffset is handled so that it is accounted for in the heights of grid lines.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

