### PR TITLE
calculates new margins for legend and redraws legend

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -684,6 +684,17 @@ export default class Plot extends Viz {
 
     });
 
+    this._redrawLegend = true;
+
+    this._legendMargin = {
+      left: xOffsetLeft,
+      right: Math.max(xDifference, x2Difference),
+      bottom: Math.max(yDifference, y2Difference),
+      top: x2Height + topOffset
+    };
+
+    super._draw(callback);
+
     return this;
 
   }

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -115,8 +115,6 @@ export default class Plot extends Viz {
   */
   _draw(callback) {
 
-    super._preDraw(callback);
-
     if (!this._filteredData.length) return this;
 
     const stackGroup = (d, i) => this._stacked
@@ -479,12 +477,10 @@ export default class Plot extends Viz {
     const y2AxisOffset = height - this._y2Test._getRange()[1];
     const y2Difference = isYAxisOrdinal ? yOffsetBottom - y2AxisOffset + this._y2Test.padding() : xHeight;
 
-    this._legendMargin = {
-      left: xOffsetLeft,
-      right: Math.max(xDifference, x2Difference),
-      bottom: Math.max(yDifference, y2Difference),
-      top: x2Height + topOffset
-    };
+    this._padding.left += xOffsetLeft;
+    this._padding.right += Math.max(xDifference, x2Difference);
+    this._padding.bottom += Math.max(yDifference, y2Difference);
+    this._padding.top += x2Height + topOffset;
 
     super._draw(callback);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #75 )

This PR goes with [this one in d3plus-viz](https://github.com/d3plus/d3plus-viz/pull/67) and together they close #75.

### Description
<!--- Describe your changes in detail -->
Creates a `legendMargin` object with margins calculated from the axes and uses this object to redraw the legend with correct margins.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

