### PR TITLE
fixes bug in Bar.js buffer

### DIFF
--- a/src/buffers/Bar.js
+++ b/src/buffers/Bar.js
@@ -20,37 +20,40 @@ export default function({data, x, y, x2, y2, buffer = 10}) {
 
   const oppDomain = oppScale.domain().slice();
 
-  if (this._discrete === "x") oppDomain.reverse();
+  const isDiscreetX = this._discrete === "x";
+
+  if (isDiscreetX) oppDomain.reverse();
 
   let negVals, posVals;
   if (this._stacked) {
     const groupedData = nest()
       .key(d => d[this._discrete])
       .entries(data)
-      .map(d => d.values.map(x => x[this._discrete === "x" ? yKey : xKey]));
+      .map(d => d.values.map(x => x[isDiscreetX ? yKey : xKey]));
     posVals = groupedData.map(arr => sum(arr.filter(d => d > 0)));
     negVals = groupedData.map(arr => sum(arr.filter(d => d < 0)));
   }
   else {
-    posVals = data.map(d => d[this._discrete === "x" ? yKey : xKey]);
+    posVals = data.map(d => d[isDiscreetX ? yKey : xKey]);
     negVals = posVals;
   }
+
   let bMax = oppScale(max(posVals));
-  if (bMax !== oppScale(0)) bMax += this._discrete === "x" ? -buffer : buffer;
+  if (isDiscreetX ? bMax < oppScale(0) : bMax > oppScale(0)) bMax += isDiscreetX ? -buffer : buffer;
   bMax = oppScale.invert(bMax);
 
   let bMin = oppScale(min(negVals));
-  if (bMin !== oppScale(0)) bMin += this._discrete === "x" ? buffer : -buffer;
+  if (isDiscreetX ? bMin > oppScale(0) : bMin < oppScale(0)) bMin += isDiscreetX ? buffer : -buffer;
   bMin = oppScale.invert(bMin);
 
   if (bMax > oppDomain[1]) oppDomain[1] = bMax;
   if (bMin < oppDomain[0]) oppDomain[0] = bMin;
 
-  if (this._discrete === "x") oppDomain.reverse();
+  if (isDiscreetX) oppDomain.reverse();
 
   oppScale.domain(oppDomain);
 
-  const discreteScale = this._discrete === "x" ? x : y;
+  const discreteScale = isDiscreetX ? x : y;
   discreteScale.domain(ordinalBuffer(discreteScale.domain()));
 
   return [x, y];

--- a/src/buffers/Bar.js
+++ b/src/buffers/Bar.js
@@ -20,40 +20,40 @@ export default function({data, x, y, x2, y2, buffer = 10}) {
 
   const oppDomain = oppScale.domain().slice();
 
-  const isDiscreetX = this._discrete === "x";
+  const isDiscreteX = this._discrete === "x";
 
-  if (isDiscreetX) oppDomain.reverse();
+  if (isDiscreteX) oppDomain.reverse();
 
   let negVals, posVals;
   if (this._stacked) {
     const groupedData = nest()
       .key(d => d[this._discrete])
       .entries(data)
-      .map(d => d.values.map(x => x[isDiscreetX ? yKey : xKey]));
+      .map(d => d.values.map(x => x[isDiscreteX ? yKey : xKey]));
     posVals = groupedData.map(arr => sum(arr.filter(d => d > 0)));
     negVals = groupedData.map(arr => sum(arr.filter(d => d < 0)));
   }
   else {
-    posVals = data.map(d => d[isDiscreetX ? yKey : xKey]);
+    posVals = data.map(d => d[isDiscreteX ? yKey : xKey]);
     negVals = posVals;
   }
 
   let bMax = oppScale(max(posVals));
-  if (isDiscreetX ? bMax < oppScale(0) : bMax > oppScale(0)) bMax += isDiscreetX ? -buffer : buffer;
+  if (isDiscreteX ? bMax < oppScale(0) : bMax > oppScale(0)) bMax += isDiscreteX ? -buffer : buffer;
   bMax = oppScale.invert(bMax);
 
   let bMin = oppScale(min(negVals));
-  if (isDiscreetX ? bMin > oppScale(0) : bMin < oppScale(0)) bMin += isDiscreetX ? buffer : -buffer;
+  if (isDiscreteX ? bMin > oppScale(0) : bMin < oppScale(0)) bMin += isDiscreteX ? buffer : -buffer;
   bMin = oppScale.invert(bMin);
 
   if (bMax > oppDomain[1]) oppDomain[1] = bMax;
   if (bMin < oppDomain[0]) oppDomain[0] = bMin;
 
-  if (isDiscreetX) oppDomain.reverse();
+  if (isDiscreteX) oppDomain.reverse();
 
   oppScale.domain(oppDomain);
 
-  const discreteScale = isDiscreetX ? x : y;
+  const discreteScale = isDiscreteX ? x : y;
   discreteScale.domain(ordinalBuffer(discreteScale.domain()));
 
   return [x, y];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #85 )

### Description
<!--- Describe your changes in detail -->
The error that @jspeis was experiencing with the bars not aligning on the x-axis was caused by a bug in the [Bar.js buffer](https://github.com/d3plus/d3plus-plot/blob/master/src/buffers/Bar.js). 

In [this particular example](https://jsfiddle.net/72zs3dm0/), the error was happening only when the year 2014 was selected. The min y value for 2014 is 32. The conditional [`bMin !== oppScale(0)`](https://github.com/d3plus/d3plus-plot/blob/master/src/buffers/Bar.js#L43) evaluates to `true` because `oppScale(32) !== oppScale(0)`. In this case, the buffer is added to `oppScale(32)` and the resulting value (which happens to be negative) becomes the new lower bound for the y domain. This is why there is the space between the x-axis and the bars.

I solved this issue by replacing the conditional [`bMin !== oppScale(0)`](https://github.com/d3plus/d3plus-plot/blob/master/src/buffers/Bar.js#L43) (which was causing false positives) with `isDiscreetX ? bMin > oppScale(0) : bMin < oppScale(0)`. This ensures that the domains only change when there is a lower bound that is outside of the scale and not when a lower bound is within the scale, but is not equal to the current lower bound. I also added this logic to the upper bound.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

