### PR TITLE
recalculates xOffsetLeft and xOffsetRight after margins and padding are set

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -333,7 +333,6 @@ export default class Plot extends Viz {
       y2Scale = "Time";
     }
 
-
     domains = {x: xDomain, x2: x2Domain || xDomain, y: yDomain, y2: y2Domain || yDomain};
 
     opps.forEach(opp => {
@@ -402,8 +401,8 @@ export default class Plot extends Viz {
       .config(this._yConfig)
       .render();
 
-    const yBounds = this._yTest.outerBounds();
-    const yWidth = yBounds.width ? yBounds.width + this._yTest.padding() : undefined;
+    let yBounds = this._yTest.outerBounds();
+    let yWidth = yBounds.width ? yBounds.width + this._yTest.padding() : undefined;
 
     this._y2Test
       .domain(y2Exists ? y2Domain : yDomain)
@@ -417,8 +416,8 @@ export default class Plot extends Viz {
       .config(this._y2Config)
       .render();
 
-    const y2Bounds = this._y2Test.outerBounds();
-    const y2Width = y2Bounds.width ? y2Bounds.width + this._y2Test.padding() : undefined;
+    let y2Bounds = this._y2Test.outerBounds();
+    let y2Width = y2Bounds.width ? y2Bounds.width + this._y2Test.padding() : undefined;
 
     const xC = {
       gridConfig: {stroke: !this._discrete || this._discrete === "y" ? this._xTest.gridConfig().stroke : "transparent"}
@@ -453,7 +452,7 @@ export default class Plot extends Viz {
     const x2Bounds = this._x2Test.outerBounds();
     const x2Height = x2Bounds.height + this._x2Test.padding();
 
-    const xOffsetLeft =  max([yWidth, this._xTest._getRange()[0], this._x2Test._getRange()[0]]);
+    let xOffsetLeft =  max([yWidth, this._xTest._getRange()[0], this._x2Test._getRange()[0]]);
 
     this._xTest
       .range([xOffsetLeft, undefined])
@@ -462,7 +461,7 @@ export default class Plot extends Viz {
     const isYAxisOrdinal = yScale === "Ordinal";
     const topOffset = isYAxisOrdinal ? this._yTest.shapeConfig().labelConfig.fontSize() : this._yTest.shapeConfig().labelConfig.fontSize() / 2;
 
-    const xOffsetRight = max([y2Width, width - this._xTest._getRange()[1], width - this._x2Test._getRange()[1]]);
+    let xOffsetRight = max([y2Width, width - this._xTest._getRange()[1], width - this._x2Test._getRange()[1]]);
     const xOffset = width - this._xTest._getRange()[1];
     const xDifference = xOffsetRight - xOffset + this._xTest.padding();
 
@@ -488,6 +487,40 @@ export default class Plot extends Viz {
 
     const horizontalMargin = this._margin.left + this._margin.right;
     const verticalMargin = this._margin.top + this._margin.bottom;
+
+    this._yTest
+      .domain(yDomain)
+      .height(height)
+      .range([x2Height, height - (yDifference + topOffset + verticalMargin)])
+      .scale(yScale.toLowerCase())
+      .select(testGroup.node())
+      .ticks(yTicks)
+      .width(width)
+      .config(yC)
+      .config(this._yConfig)
+      .render();
+
+    yBounds = this._yTest.outerBounds();
+    yWidth = yBounds.width ? yBounds.width + this._yTest.padding() : undefined;
+    xOffsetLeft =  max([yWidth, this._xTest._getRange()[0], this._x2Test._getRange()[0]]);
+
+    this._y2Test
+      .config(yC)
+      .domain(y2Exists ? y2Domain : yDomain)
+      .gridSize(0)
+      .height(height)
+      .range([x2Height, height - (y2Difference + topOffset + verticalMargin)])
+      .scale(y2Exists ? y2Scale.toLowerCase() : yScale.toLowerCase())
+      .select(testGroup.node())
+      .width(width - max([0, xOffsetRight - y2Width]))
+      .title(false)
+      .config(this._y2Config)
+      .config(defaultY2Config)
+      .render();
+
+    y2Bounds = this._y2Test.outerBounds();
+    y2Width = y2Bounds.width ? y2Bounds.width + this._y2Test.padding() : undefined;
+    xOffsetRight = max([y2Width, width - this._xTest._getRange()[1], width - this._x2Test._getRange()[1]]);
 
     const transform = `translate(${this._margin.left}, ${this._margin.top + x2Height + topOffset})`;
     const x2Transform = `translate(${this._margin.left}, ${this._margin.top + topOffset})`;


### PR DESCRIPTION
(closes #88 )

<!--- Provide a general summary of your changes in the title above -->

### Description
<!--- Describe your changes in detail -->
#88 was occurring because margins decreased the height of the y-axis so its title which used to fit on a single line, needed to be rendered on multiple lines and took up more horizontal space. 

To solve this issue, I added logic that re-renders the `yTest` and `y2Test` axes after the margins are calculated so that the updated widths of these axes can be used to render the x-axis correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

