### PR TITLE
adds default x-axis maxSize of half the viz height

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -426,6 +426,7 @@ export default class Plot extends Viz {
     this._xTest
       .domain(xDomain)
       .height(height)
+      .maxSize(height / 2)
       .range([undefined, undefined])
       .scale(xScale.toLowerCase())
       .select(testGroup.node())
@@ -538,6 +539,7 @@ export default class Plot extends Viz {
     this._xAxis
       .domain(xDomain)
       .height(height - (x2Height + topOffset + verticalMargin))
+      .maxSize(height / 2)
       .range([xOffsetLeft, width - (xDifference + horizontalMargin)])
       .scale(xScale.toLowerCase())
       .select(xGroup.node())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR along with [this PR in D3plus-axis](https://github.com/d3plus/d3plus-axis/pull/57) close #89 .

### Description
<!--- Describe your changes in detail -->
Sets the default `maxSize` for the x-axis to be half the height of the viz. To override this default `maxSize`, the user can supply their own value for `maxSize` in the `xConfig`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

