### PR TITLE
resets ranges on yTest and y2Test axes

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -402,6 +402,7 @@ export default class Plot extends Viz {
       .domain(yDomain)
       .height(height)
       .maxSize(width / 2)
+      .range([undefined, undefined])
       .scale(yScale.toLowerCase())
       .select(testGroup.node())
       .ticks(yTicks)
@@ -416,6 +417,7 @@ export default class Plot extends Viz {
     this._y2Test
       .domain(y2Exists ? y2Domain : yDomain)
       .height(height)
+      .range([undefined, undefined])
       .scale(y2Exists ? y2Scale.toLowerCase() : yScale.toLowerCase())
       .select(testGroup.node())
       .ticks(y2Ticks ? y2Ticks : yTicks)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
(closes #95 , closes #96 )

### Description
<!--- Describe your changes in detail -->
The bug was caused because when the `yTest` and `y2Test` axes are rendered a subsequent time (due to a change in height or data for example) they are not passed a new range and retain the range passed to them on the initial render.

[There is logic in d3plus-axis](https://github.com/d3plus/d3plus-axis/blob/master/src/Axis.js#L217) that checks for an existing range value when drawing the axis and it was incorrectly being used on re-renders and was causing incorrect heights on the `yTest` and `y2Test` axes.

To fix this bug, I set the ranges of the `yTest` and `y2Test` axes to `[undefined, undefined]`, which is the correct initial value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

