### PR TITLE
Fixes uncatched false value in axis title logic

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -355,7 +355,7 @@ export default class Plot extends Viz {
         }
 
         // set axis title if not discrete
-        if (str !== k && (!this[`_${k}Config`].title || this[`_${k}Title`] === this[`_${k}Config`].title) && this._discrete !== k) {
+        if (str !== k && this[`_${k}Title`] === this[`_${k}Config`].title && this._discrete !== k) {
           this[`_${k}Title`] = str;
           this[`_${k}Config`].title = str;
         }

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -355,7 +355,7 @@ export default class Plot extends Viz {
         }
 
         // set axis title if not discrete
-        if (str !== k && this[`_${k}Title`] === this[`_${k}Config`].title && this._discrete !== k) {
+        if (str !== k && (!this[`_${k}Config`].title === undefined || this[`_${k}Title`] === this[`_${k}Config`].title) && this._discrete !== k) {
           this[`_${k}Title`] = str;
           this[`_${k}Config`].title = str;
         }

--- a/src/Plot.js
+++ b/src/Plot.js
@@ -355,7 +355,7 @@ export default class Plot extends Viz {
         }
 
         // set axis title if not discrete
-        if (str !== k && (!this[`_${k}Config`].title === undefined || this[`_${k}Title`] === this[`_${k}Config`].title) && this._discrete !== k) {
+        if (str !== k && this[`_${k}Title`] === this[`_${k}Config`].title && this._discrete !== k) {
           this[`_${k}Title`] = str;
           this[`_${k}Config`].title = str;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR adds a minor fix that solves the uncatched false value in axis title logic, related to issue #167.

### Description
<!--- Describe your changes in detail -->
Checking the logic of axis titles config, i found a private function which does the preDraw of each [Plot](https://github.com/d3plus/d3plus-plot/blob/f6df9c4199e061fcecbafa4b8258cfb32a9f0ff6/src/Plot.js#L358). This funcionality defines the logic to set titles to non-discrete axis (which are the ones with title issues).
To solve this issue, i removed the ```!this[`_${k}Config`].title``` condition which is `true` if `axisConfig.title = false` is defined, forcing a title to each not discrete axis by default.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.