### PR TITLE
allows Line shapes to be color by colorScale value

### DIFF
--- a/src/Plot.js
+++ b/src/Plot.js
@@ -279,7 +279,6 @@ export default class Plot extends Viz {
           textAnchor: "start",
           verticalAlign: "middle"
         },
-        stroke: (d, i) => colorAssign(this._id(d, i)),
         strokeWidth: constant(2)
       },
       Rect: {


### PR DESCRIPTION
`Line` shapes have a static `colorAssign` function in the default config, which overwrites the `colorScale` logic that is typically interited by the default `shapeConfig.fill` in the `Viz` class.

Removing this one line allows Lines to be colored using `colorScale`, with one caveat:

**If users do not want the `sum` of all values in a Line to be used, then they must define a custom `aggs` function.**

As an example, here is how you would color something using the max value (cc @AlanORB):

```js
.config({
  aggs: {
    "Growth %": (arr, cb) => Math.max(...arr.map(cb))
  },
  colorScale: "Growth %",
})
```